### PR TITLE
Update ups.php

### DIFF
--- a/upload/catalog/model/extension/shipping/ups.php
+++ b/upload/catalog/model/extension/shipping/ups.php
@@ -203,7 +203,7 @@ class ModelExtensionShippingUps extends Model {
 			$xml .= '</RatingServiceSelectionRequest>';
 
 			if (!$this->config->get('ups_test')) {
-				$url = 'https://www.ups.com/ups.app/xml/Rate';
+				$url = 'https://onlinetools.ups.com/ups.app/xml/Rate';
 			} else {
 				$url = 'https://wwwcie.ups.com/ups.app/xml/Rate';
 			}


### PR DESCRIPTION
$url = 'https://www.ups.com/ups.app/xml/Rate';

has been changed to this a while ago, to make UPS work:

$url = 'https://onlinetools.ups.com/ups.app/xml/Rate';

---
More Info on this here:
https://forum.opencart.com/viewtopic.php?f=198&t=223123#p817760